### PR TITLE
expose task-specific compute resources in run_parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Expose task-specific compute resources in `run_parallel`/`build_parallel_task_graph` via a `per_task_resources` callable (requires `flat_node_args`).
 
 ## [1.0.27] - 2025-07-10
 ### Added

--- a/src/rra_tools/jobmon.py
+++ b/src/rra_tools/jobmon.py
@@ -86,6 +86,7 @@ def build_parallel_task_graph(  # type: ignore[no-untyped-def] # noqa: PLR0913
     op_args: dict[str, Any] | None = None,
     max_attempts: int | None = None,
     resource_scales: dict[str, Any] | None = None,
+    per_task_resources: Callable[[tuple[Any, ...]], dict[str, Any]] | None = None,
 ) -> list[Any]:
     """Build a parallel task graph for jobmon.
 
@@ -126,6 +127,12 @@ def build_parallel_task_graph(  # type: ignore[no-untyped-def] # noqa: PLR0913
         should take a single numeric value as its sole argument. Any Iterator should
         only yield numeric values. Any Iterable can be easily converted to an
         Iterator by using the iter() built-in (e.g. iter([80, 160, 190])).
+    per_task_resources
+        A callable mapping each flat_node_args value tuple (in the same order
+        as the argument names) to a dict of compute resources for that task
+        (e.g. {"memory": "50G", "runtime": "30m"}). The returned dict is merged
+        over task_resources, so only the resources that vary need to be
+        provided. Requires flat_node_args.
 
 
     Returns
@@ -138,6 +145,9 @@ def build_parallel_task_graph(  # type: ignore[no-untyped-def] # noqa: PLR0913
 
     if node_args is not None and flat_node_args is not None:
         msg = "node_args and flat_node_args are mutually exclusive."
+        raise ValueError(msg)
+    if per_task_resources is not None and flat_node_args is None:
+        msg = "per_task_resources requires flat_node_args."
         raise ValueError(msg)
     if flat_node_args is not None:
         node_arg_string = " ".join(
@@ -176,10 +186,16 @@ def build_parallel_task_graph(  # type: ignore[no-untyped-def] # noqa: PLR0913
                 **clean_task_args,
                 **clean_op_args,
             }
+            compute_resources = (
+                {**task_resources, **per_task_resources(args)}
+                if per_task_resources is not None
+                else None
+            )
             task = task_template.create_task(
                 **task_args,
                 max_attempts=max_attempts,
                 resource_scales=resource_scales,
+                compute_resources=compute_resources,
             )
             tasks.append(task)
     else:
@@ -243,6 +259,7 @@ def run_parallel(  # noqa: PLR0913
     concurrency_limit: int = 10000,
     max_attempts: int | None = None,
     resource_scales: dict[str, Any] | None = None,
+    per_task_resources: Callable[[tuple[Any, ...]], dict[str, Any]] | None = None,
     log_root: str | Path | None = None,
     log_method: Callable[[str], None] = print,
 ) -> str:
@@ -290,6 +307,12 @@ def run_parallel(  # noqa: PLR0913
         should take a single numeric value as its sole argument. Any Iterator should
         only yield numeric values. Any Iterable can be easily converted to an
         Iterator by using the iter() built-in (e.g. iter([80, 160, 190])).
+    per_task_resources
+        A callable mapping each flat_node_args value tuple (in the same order
+        as the argument names) to a dict of compute resources for that task
+        (e.g. {"memory": "50G", "runtime": "30m"}). The returned dict is merged
+        over task_resources, so only the resources that vary need to be
+        provided. Requires flat_node_args.
     log_root
         The root directory for the logs. Default is None.
     log_method
@@ -335,6 +358,7 @@ def run_parallel(  # noqa: PLR0913
         runner=runner,
         max_attempts=max_attempts,
         resource_scales=resource_scales,
+        per_task_resources=per_task_resources,
     )
 
     workflow.add_tasks(tasks)


### PR DESCRIPTION
## Description

`run_parallel` currently applies a single `task_resources` request to every task in the
workflow. For workflows with heterogeneous tasks (e.g. per-country jobs in the population
model, where memory requirements span two orders of magnitude), that means either
over-provisioning everything or leaning on `resource_scales` retries — and the retry
ladder gets very slow when the cluster is busy, since each rung waits for a large
allocation just to try again. Splitting into resource-tiered workflows helps but
serializes scheduling behind the slowest jobs of each upstream workflow.

Jobmon natively supports task-level resources (`TaskTemplate.create_task(compute_resources=...)`,
merged over the template defaults); this PR exposes that in `run_parallel` /
`build_parallel_task_graph` via a new optional `per_task_resources` argument — a callable
mapping each `flat_node_args` value tuple to a partial resources dict, merged over
`task_resources`:

    jobmon.run_parallel(
        ...,
        task_resources={"queue": queue, "memory": "8G", "runtime": "10m", ...},
        flat_node_args=(("location-id", "time-point"), to_run),
        per_task_resources=lambda args: {"memory": f"{mem_gb[args[0]]}G"},
    )

Notes:

- Fully backwards compatible: when `per_task_resources` is omitted, `compute_resources=None`
  is passed, which is `create_task`'s existing default — no behavior change for current callers.
- Only supported with `flat_node_args`; combining with `node_args` (which uses the bulk
  `create_tasks` path) raises a `ValueError`.
- The callable's return is merged as `{**task_resources, **override}`, so tasks keep the
  queue/project/log settings and only need to supply the resources that vary.

Verified against the jobmon client directly: tasks receive their individual memory values
with template defaults (queue, project, stdout/stderr) intact; the legacy path sets no
task-level resources; the validation error fires; existing tests pass.

## Checklist

- [ ] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant

🤖 Generated with [Claude Code](https://claude.com/claude-code)